### PR TITLE
Show current color of the lamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# HueVue: a Vue-based client for Philips Hue
+# HueJS: a Vue-based client for Philips Hue
 
-HueVue is a simple web client for Philips Hue systems built with Vue. It connects directly to the Hue hub (so you need to be in the same network).
+HueJS is a simple web client for Philips Hue systems built with Vue. It connects directly to the Hue hub (so you need to be in the same network).
 
 ## Installation
 
@@ -8,4 +8,4 @@ Simply clone this repository and point your browser to index.html. Insert the IP
 
 ## License
 
-HueVue is licensed under the MIT license (see the LICENSE file)
+HueJS is licensed under the MIT license (see the LICENSE file)

--- a/default.css
+++ b/default.css
@@ -17,12 +17,12 @@ button {
 }
 
 li {
-	list-style-type: circle;
+	list-style-type: disc;
 	margin-left: 20px;
 }
 
 article {
-	padding: 5px;
+	padding: 10px;
 	padding-left: 15px;
 }
 
@@ -38,6 +38,9 @@ h1 {
 
 h2 {
 	font-size: 11pt;
+	margin-bottom: 10px;
+	margin-top: 10px;
+	display: inline-block;
 }
 
 h3 {
@@ -83,4 +86,45 @@ h3 {
 	left: 0px;
 	top: 0px;
 	height: 100%;
+}
+
+table {
+	border-collapse: collapse;
+	border: none;
+}
+
+table th {
+	font-weight: bold;
+	background-color: rgba(0,55,100,1.0);
+	color: white;
+}
+
+table tr td, table tr th {
+	padding: 5px;
+	vertical-align: top;
+	text-align: left;
+}
+
+table tr {
+	padding: 5px;
+	border: none;
+	border-collapse: collapse;
+}
+
+table tr:nth-child(2n+1) {
+	background-color: #EFEFEF;
+}
+
+abbr {
+	border-bottom: dotted 1px #A0A0A0;
+}
+
+details summary {
+	outline: none;
+	cursor: pointer;
+}
+
+details {
+	margin-top: 5px;
+	margin-bottom: 5px;
 }

--- a/huevue.js
+++ b/huevue.js
@@ -8,6 +8,21 @@ Vue.component('hue-battery', {
 	}
 });
 
+Vue.component('hue-time', {
+	template: '#hue-time',
+	props: {
+		time: {type: Date}
+	}
+});
+
+Vue.component('hue-rule-tr', {
+	template: '#hue-rule-tr',
+	props: {
+		rule: {type: Object},
+		hueId: {type: String}
+	}
+});
+
 Vue.component('hue-group', {
 	template: '#hue-group',
 	props: {
@@ -68,13 +83,69 @@ Vue.component('hue-sensor', {
 	},
 
 	methods: {
+	},
+
+	computed: {
+		button: function() {
+			let btnId = Math.floor(this.sensor.state.buttonevent / 1000);
+			switch(btnId) {
+				case 1: return "on button";
+				case 2: return "up button";
+				case 3: return "down button";
+				case 4: return "off button";
+				default: return "unknown button";
+			}
+		},
+
+		buttonPressType: function() {
+			let type = this.sensor.state.buttonevent % 1000;
+			switch(type) {
+				case 0: return "pressed";
+				case 1: return "hold";
+				case 2: return "released (short)";
+				case 3: return "released (long)";
+				default: return "unknown " + type;
+			}
+		},
+
+		lux: function() {
+			return Math.round(Math.pow(10, (this.sensor.state.lightlevel-1)/10000));
+		},
+
+		luxExplanation: function() {
+			var lux = this.lux;
+
+			if(lux <= 1) { return "bright moonlight"; }
+			if(lux <= 2) { return "nightlight"; }
+			if(lux <= 10) { return "dimmed light"; }
+			if(lux <= 50) { return "cosy living room"; }
+			if(lux <= 150) { return "normal"; }
+			if(lux <= 350) { return "working/reading light"; }
+			if(lux <= 700) { return "inside daylight"; }
+			if(lux <= 2000) { return "very bright"; }
+			else { return "outside light / direct sunlight"; }
+		}
 	}
 });
 
 var app = new Vue({
 	el: '#app',
 	data: function() {
-		var initial = {bridge: '', user: '', lights: {},  sensors: {}, schedules: {}, resourcelinks: {}, scenes: {}, groups: {}, config: {}, connected: false};
+		var initial = {
+			bridge: '', 
+			user: '', 
+			connected: false,
+
+			// Hue state data
+			lights: {},  
+			sensors: {}, 
+			schedules: {}, 
+			resourcelinks: {}, 
+			scenes: {}, 
+			groups: {}, 
+			config: {},
+			rules: {},
+		};
 
 		try {
 			if("hue" in window.localStorage) {
@@ -125,6 +196,7 @@ var app = new Vue({
 				self.groups = msg.groups;
 				self.scenes = msg.scenes;
 				self.config = msg.config;
+				self.rules = msg.rules;
 			});
 		},
 

--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
 				<h3>{{light.name}}</h3>
 				{{Math.round(light.state.bri/255*100)}}%
 				<button v-on:click="toggle(!light.state.on)">Toggle</button>
-				<input type="color" v-on:change="colour">
+				<input type="color" v-on:change="colour" :value="toHex(light.state)">
 			</div>
 		</template>
 

--- a/index.html
+++ b/index.html
@@ -40,26 +40,74 @@
 			</article>
 
 			<article>
-				<h2>Schedules</h2>
-				<ul>
-					<hue-schedule :schedule="schedule" :hue-id="scheduleId" v-for="(schedule, scheduleId) in schedules" :key="scheduleId" v-on:call="call"/>
-				</ul>
-			</article>
+				<details>
+					<summary><h2>Schedules</h2></summary>
+					<ul>
+						<hue-schedule :schedule="schedule" :hue-id="scheduleId" v-for="(schedule, scheduleId) in schedules" :key="scheduleId" v-on:call="call"/>
+					</ul>
+				</details>
 
-			<article>
-				<h2>Resource links</h2>
-				<ul>
-					<hue-resource-link :link="link" :hue-id="linkId" v-for="(link, linkId) in resourcelinks" :key="linkId" v-on:call="call"/>
-				</ul>
-			</article>
+				<details>
+					<summary><h2>Resource links</h2></summary>
+					<ul>
+						<hue-resource-link :link="link" :hue-id="linkId" v-for="(link, linkId) in resourcelinks" :key="linkId" v-on:call="call"/>
+					</ul>
+				</details>
 
-			<article>
-				<h2>Groups</h2>
-				<ul>
-					<hue-group :group="group" :hue-id="groupId" v-for="(group, groupId) in groups" :key="groupId" v-on:call="call"/>
-				</ul>
+				<details>
+					<summary><h2>Groups</h2></summary>
+					<ul>
+						<hue-group :group="group" :hue-id="groupId" v-for="(group, groupId) in groups" :key="groupId" v-on:call="call"/>
+					</ul>
+				</details>
+
+				<details>
+					<summary><h2>Rules</h2></summary>
+					<table>
+						<thead>
+							<tr>
+								<th>Rule name</th>
+								<th>Last triggered</th>
+								<th>Conditions</th>
+								<th>Actions</th>
+							</tr>
+						</thead>
+
+						<tbody>
+							<tr is="hue-rule-tr" :rule="rule" :hue-id="ruleId" v-for="(rule, ruleId) in rules" :key="ruleId" v-on:call="call"></tr>
+						</tbody>
+					</table>
+				</details>
 			</article>
 		</div>
+
+		<template id="hue-time">
+			<span>
+				{{time.toLocaleString()}}
+			</span>
+		</template>
+
+		<template id="hue-rule-tr">
+			<tr>			
+				<td>{{rule.name}}</td>
+				<td><hue-time :time="new Date(rule.lasttriggered)"/></td>
+				<td>
+					<ul>
+						<li v-for="cond in rule.conditions">
+							{{cond.address}} {{cond.operator}} {{cond.value}}
+						</li>
+					</ul>
+				</td>
+
+				<td>
+					<ul>
+						<li v-for="action in rule.actions">
+							{{action.address}} =&gt; {{action.body}}
+						</li>
+					</ul>
+				</td>
+			</tr>
+		</template>
 
 		<template id="hue-light">
 			<div :class="{'hue-light':true, 'on': light.state.on}">
@@ -104,15 +152,15 @@
 				<h3>{{sensor.name}}</h3> 
 
 				<template v-if="sensor.type == 'ZLLTemperature' ">
-					 Temperature: {{Math.round(sensor.state.temperature/100)}}˚
+					 Temperature: {{Math.round(sensor.state.temperature/10)/10}}˚
 				</template>
 
 				<template v-if="sensor.type == 'ZLLSwitch' ">
-					 Last event: {{sensor.state.buttonevent}}
+					 Last event: {{button}} {{buttonPressType}}
 				</template>
 
 				<template v-if="sensor.type == 'ZLLLightLevel' ">
-					 Light level: {{Math.round(sensor.state.lightlevel/100)}} Lux 
+					 <abbr :title="this.lux + ' lux' ">{{luxExplanation}}</abbr>
 					 <template v-if="sensor.state.daylight">(daylight)</template>
 					 <template v-if="sensor.state.dark">(dark)</template>
 				</template>


### PR DESCRIPTION
Reads the current state of the lamp and will set the colour-picker to the current colour of the lamp.

Note that it seems like that the roundtrip conversion of RGB to XY colourspace is lossy; Setting the lamp to a clean green #00FF00; wil come back from the lamp as #03FF4A, which is green as well,.. but still not quite te same colour.

I took the conversion algorithm from the [hue developers website](https://developers.meethue.com/documentation/color-conversions-rgb-xy), but it can't hurt to double check my work.